### PR TITLE
Prediction using UITextChecker

### DIFF
--- a/Keyboard/foriOS/Keyboard/ContainingApplication/Commands.swift
+++ b/Keyboard/foriOS/Keyboard/ContainingApplication/Commands.swift
@@ -1,0 +1,23 @@
+//
+//  Commands.swift
+//
+// (c) 2020 The ACE Centre-North, UK registered charity 1089313.
+// MIT licensed, see https://opensource.org/licenses/MIT
+//
+
+import Foundation
+
+struct Commands {
+    struct Ready {
+        static let name = "ready"
+    }
+    struct Predict {
+        static let name = "predict"
+        struct Args {
+            static let input = "input"
+        }
+        struct Ret {
+            static let predictions = "predictions"
+        }
+    }
+}

--- a/Keyboard/foriOS/Keyboard/ContainingApplication/MainViewController.swift
+++ b/Keyboard/foriOS/Keyboard/ContainingApplication/MainViewController.swift
@@ -17,12 +17,27 @@ class MainViewController: CaptiveWebView.DefaultViewController {
         ) throws -> Dictionary<String, Any>
     {
         switch command {
-        case "ready":
+        case Commands.Ready.name:
             return [:]
+        case Commands.Predict.name:
+            return predict(args: commandDictionary)
         default:
             return try super.response(to: command, in: commandDictionary)
         }
     }
-
+    
+    /// Handle the 'predict' command.
+    /// - Parameter args: Command arguments.
+    func predict(args: Dictionary<String, Any>) -> Dictionary<String, Any> {
+        guard let input = args[Commands.Predict.Args.input] as? String else {
+            return [:]
+        }
+        
+        if input.count > 0, let predictions = Predictor.predictions(for: input) {
+            return [Commands.Predict.Ret.predictions: predictions]
+        }
+        
+        return [:]
+    }
 }
 

--- a/Keyboard/foriOS/Keyboard/ContainingApplication/Predictor.swift
+++ b/Keyboard/foriOS/Keyboard/ContainingApplication/Predictor.swift
@@ -1,0 +1,19 @@
+//
+//  Predictor.swift
+//
+// (c) 2020 The ACE Centre-North, UK registered charity 1089313.
+// MIT licensed, see https://opensource.org/licenses/MIT
+//
+
+import UIKit
+
+class Predictor {
+    private static let textChecker = UITextChecker()
+    
+    /// Generates a series of word predictions for the given incomplete word.
+    /// Reference: https://nshipster.com/uitextchecker/
+    /// - Parameter input: An incomplete word.
+    static func predictions(for input: String) -> [String]? {
+        return textChecker.completions(forPartialWordRange: NSRange(0..<input.utf16.count), in: input, language: "en_US")
+    }
+}

--- a/Keyboard/foriOS/Keyboard/Keyboard.xcodeproj/project.pbxproj
+++ b/Keyboard/foriOS/Keyboard/Keyboard.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		04D77CBC23BB56B500C25698 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D77CBB23BB56B500C25698 /* MainViewController.swift */; };
 		04D77CC123BB56B700C25698 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 04D77CC023BB56B700C25698 /* Assets.xcassets */; };
 		04D77CC423BB56B700C25698 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 04D77CC223BB56B700C25698 /* LaunchScreen.storyboard */; };
+		26F46D3C23EBE32C00B00168 /* Predictor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F46D3B23EBE32C00B00168 /* Predictor.swift */; };
+		26F46D3E23EBE62A00B00168 /* Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F46D3D23EBE62A00B00168 /* Commands.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +68,8 @@
 		04D77CC023BB56B700C25698 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		04D77CC323BB56B700C25698 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		04D77CC523BB56B700C25698 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		26F46D3B23EBE32C00B00168 /* Predictor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Predictor.swift; sourceTree = "<group>"; };
+		26F46D3D23EBE62A00B00168 /* Commands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Commands.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -132,6 +136,8 @@
 				04D77CC023BB56B700C25698 /* Assets.xcassets */,
 				04D77CC223BB56B700C25698 /* LaunchScreen.storyboard */,
 				04D77CC523BB56B700C25698 /* Info.plist */,
+				26F46D3B23EBE32C00B00168 /* Predictor.swift */,
+				26F46D3D23EBE62A00B00168 /* Commands.swift */,
 			);
 			path = ContainingApplication;
 			sourceTree = "<group>";
@@ -249,7 +255,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				04D77CBC23BB56B500C25698 /* MainViewController.swift in Sources */,
+				26F46D3C23EBE32C00B00168 /* Predictor.swift in Sources */,
 				04D77CBA23BB56B500C25698 /* AppDelegate.swift in Sources */,
+				26F46D3E23EBE62A00B00168 /* Commands.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/browser/captivedasher.js
+++ b/browser/captivedasher.js
@@ -8,6 +8,7 @@
 import PageBuilder from "./pagebuilder.js";
 
 import UserInterface from "./userinterface.js"
+import PredictorCompletions from "./predictor_completions.js"
 
 class CaptiveDasher {
     constructor(bridge) {
@@ -33,7 +34,9 @@ class CaptiveDasher {
             return Object.assign(command, {"confirm": "CaptiveDasher"});
         };
         this._transcribe({"step": "constructing"});
-        const ui = new UserInterface(this._builder.node).load(null, footerID);
+        const ui = new UserInterface(this._builder.node);
+        ui.predictor = new PredictorCompletions(bridge);
+        ui.load(null, footerID);
 
         // ui.stopCallback = () => {
         //     if (ui.message !== "") {

--- a/browser/predictor.js
+++ b/browser/predictor.js
@@ -17,44 +17,44 @@ const codePointSpace = " ".codePointAt(0);
 const codePointStop = ".".codePointAt(0);
 
 export default class Predictor {
-    // constructor() {
-    //     console.log(JSON.stringify(
-    //         Predictor.characterGroups, undefined, 4));
-    // }
-
     get(message, prediction) {
-        const lastIndex = message.length - 1;
+        
+        return new Promise(function(resolve, reject) {
+                           
+            const lastIndex = message.length - 1;
 
-        // Check if the messages ends full stop, space.
-        const stopSpace = (
-            lastIndex > 1 && message[lastIndex - 1] === codePointStop &&
-            message[lastIndex] === codePointSpace
-        );
-        const weighted = (prediction === null || stopSpace) ? "capital" : null;
-        const boosted = prediction === null ? null : prediction.boosted;
-        const only = prediction === null ? null : prediction.group;
+            // Check if the messages ends full stop, space.
+            const stopSpace = (
+                lastIndex > 1 && message[lastIndex - 1] === codePointStop &&
+                message[lastIndex] === codePointSpace
+            );
+            const weighted = (prediction === null || stopSpace) ? "capital" : null;
+            const boosted = prediction === null ? null : prediction.boosted;
+            const only = prediction === null ? null : prediction.group;
 
-        const returning = [];
-        for (const group of Predictor.characterGroups) {
-            if (group.name === boosted || group.name === only) {
-                group.codePoints.forEach(codePoint => returning.push({
-                    "codePoint": codePoint,
-                    "group": null,
-                    "boosted": group.boost,
-                    "weight":
-                        (Predictor.vowelCodePoints.includes(codePoint) ? 2 : 1)
-                }));
+            const returning = [];
+            for (const group of Predictor.characterGroups) {
+                if (group.name === boosted || group.name === only) {
+                    group.codePoints.forEach(codePoint => returning.push({
+                        "codePoint": codePoint,
+                        "group": null,
+                        "boosted": group.boost,
+                        "weight":
+                            (Predictor.vowelCodePoints.includes(codePoint) ? 2 : 1)
+                    }));
+                }
+                else if (only === null) {
+                    returning.push({
+                        "codePoint": null,
+                        "group": group.name,
+                        "boosted": group.name,
+                        "weight": group.name === weighted ? 20 : 1
+                    })
+                }
             }
-            else if (only === null) {
-                returning.push({
-                    "codePoint": null,
-                    "group": group.name,
-                    "boosted": group.name,
-                    "weight": group.name === weighted ? 20 : 1
-                })
-            }
-        }
-        return returning;
+
+            resolve(returning);
+        });
     }
 }
 

--- a/browser/predictor_completions.js
+++ b/browser/predictor_completions.js
@@ -1,0 +1,134 @@
+// (c) 2020 The ACE Centre-North, UK registered charity 1089313.
+// MIT licensed, see https://opensource.org/licenses/MIT
+
+/*
+A predictor instance must have a `get` method that returns an array of objects
+each with the following properties.
+
+-   `codePoint`, the next text, like a letter, as a Unicode code point value.
+-   `weight`, the visual weighting to be given to this box.
+-   `group`, a group name like "capital" or null if this item doesn't represent
+    a group.
+-   Other custom properties for the use of the predictor, next time around.
+    The Predictor class here adds one custom property: `boosted`.
+*/
+
+const codePointSpace = " ".codePointAt(0);
+const codePointStop = ".".codePointAt(0);
+
+export default class PredictorCompletions {
+
+     constructor(bridge) {
+         this._bridge = bridge;
+         this._currentText = null
+         this._currentPrediction = null
+     }
+
+    get(message, prediction) {
+        if (this._currentText !== null && this._currentText === message) {
+            if (this._currentPrediction !== null) {
+                return Promise.resolve(this._currentPrediction);
+            }
+        }
+        
+        var bridge = this._bridge;
+        return new Promise(function(resolve, reject) {
+            
+            bridge.sendObject({"command": "predict", "input" : message})
+            .then(response => {
+                  const lastIndex = message.length - 1;
+
+                  // Check if the messages ends full stop, space.
+                  const stopSpace = (
+                      lastIndex > 1 && message[lastIndex - 1] === codePointStop &&
+                      message[lastIndex] === codePointSpace
+                  );
+                  const weighted = (prediction === null || stopSpace) ? "capital" : null;
+                  const boosted = prediction === null ? null : prediction.boosted;
+                  const only = prediction === null ? null : prediction.group;
+
+                  const returning = [];
+                  
+                  var predictionsSet = new Set();
+                  var predictions = null;
+                  if (response["predictions"] !== undefined) {
+                      var p = response["predictions"];
+                      p.forEach(word => {
+                        if (word.length >= message.length + 1) {
+                            var w = word.substring(message.length, message.length + 1);
+                            predictionsSet.add(w.codePointAt(0));
+                        }
+                      });
+                  }
+                  
+                  for (const group of PredictorCompletions.characterGroups) {
+                      if (group.name === boosted || group.name === only) {
+                        group.codePoints.forEach(codePoint => {
+                            var weight = (PredictorCompletions.vowelCodePoints.includes(codePoint) ? 2 : 1);
+                            if (predictionsSet.has(codePoint)) {
+                                weight = 10;
+                            }
+                            returning.push({
+                              "codePoint": codePoint,
+                              "group": weight === 10 ? "highlight" : null,
+                              "boosted": group.boost,
+                              "weight": weight
+                            });
+                        });
+                      }
+                      else if (only === null) {
+                          returning.push({
+                              "codePoint": null,
+                              "group": group.name,
+                              "boosted": group.name,
+                              "weight": group.name === weighted ? 20 : 1
+                          })
+                      }
+                  }
+                  
+                  resolve(returning);
+            })
+            .catch(error => reject("An error occurred whilst trying to generate predictions"));
+        });
+    }
+}
+
+PredictorCompletions.characterGroups = [
+    {
+        "name": "small", "boost": "small",
+        "firstPoint": "a".codePointAt(0), "lastPoint": "z".codePointAt(0)
+    }, {
+        "name": "capital", "boost": "small",
+        "firstPoint": "A".codePointAt(0), "lastPoint": "Z".codePointAt(0)
+    }, {
+        "name": "numeral", "boost": "numeral",
+        "firstPoint": "0".codePointAt(0), "lastPoint": "9".codePointAt(0)
+    }, {
+        "name": "punctuation", "boost": "space", "texts": [
+            ",", ".", "&", "!", "?"
+        ]
+    }, {
+        "name": "space", "boost": "small", "texts": [
+            " ", "\n"
+        ]
+    }
+];
+
+PredictorCompletions.characterGroups.forEach(group => {
+    if (!("texts" in group)) {
+        group.texts = [];
+        for (
+            let codePoint = group.firstPoint;
+            codePoint <= group.lastPoint;
+            codePoint++
+        ) {
+            group.texts.push(String.fromCodePoint(codePoint));
+        }
+    }
+    group.codePoints = group.texts.map(text => text.codePointAt(0));
+});
+
+
+PredictorCompletions.vowelTexts = ["a", "e", "i", "o", "u"];
+PredictorCompletions.vowelCodePoints = PredictorCompletions.vowelTexts.map(
+    text => text.codePointAt(0));

--- a/browser/userinterface.js
+++ b/browser/userinterface.js
@@ -28,6 +28,7 @@ export default class UserInterface {
         this._keyboardMode = parent.classList.contains("keyboard");
 
         this._zoomBox = null;
+        this._predictor = null;
 
         this._controllerRandom = new ControllerRandom(
             "abcdefghijklmnopqrstuvwxyz".split(""));
@@ -120,6 +121,13 @@ export default class UserInterface {
         this._messageDisplay.node.textContent = (
             message === undefined ? null : message);
     }
+    
+    get predictor() {
+        return this._predictor;
+    }
+    set predictor(predictor) {
+        this._predictor = predictor;
+    }
 
     load(loadingID, footerID) {
         this._header = new Piece('div', this._parent);
@@ -140,9 +148,10 @@ export default class UserInterface {
         this._load_pointer(diagnosticSpans);
         this._load_settings();
 
-        const predictor = new Predictor();
+        this._load_predictor();
+        
         this._controllerPointer = new ControllerPointer(
-            this._pointer, predictor.get.bind(predictor));
+            this._pointer, this._predictor.get.bind(this._predictor));
     
         // Grab the footer, which holds some small print, and re-insert it. The
         // small print has to be in the static HTML too.
@@ -158,6 +167,12 @@ export default class UserInterface {
         // To-do: should be an async function that returns a promise that
         // resolves to this.
         return this;
+    }
+    
+    _load_predictor() {
+        if (this._predictor === null) {
+            this._predictor = new Predictor();
+        }
     }
 
     _load_message() {
@@ -515,7 +530,12 @@ export default class UserInterface {
         this._controller.populate(zoomBox, this._limits);
 
         this.zoomBox = zoomBox;
-        this._start_render(startRender);
+        
+        var instance = this;
+        
+        this.zoomBox.ready
+        .then(result => instance._start_render(startRender) )
+        .catch(error => console.log("ZoomBox is not ready and an error occurred: " + error) );
     }
 
     reset() {

--- a/browser/zoombox.js
+++ b/browser/zoombox.js
@@ -33,22 +33,39 @@ export default class ZoomBox {
 
         this._controllerSettings = specification.controllerSettings;
         this._viewer = null;
-
-        this._childSpecifications = (
-            this._specification.spawner ?
-            this._specification.spawner.child_specifications(this) :
-            []
-        );
-        this._childCount = this._childSpecifications.length;
+        
+        this._childSpecifications = [];
+        this._childCount = 0;
         this._totalWeight = this._childSpecifications.reduce(
             (accumulator, specification) => accumulator + specification.weight,
             0
         );
-
-        // childBoxes is a sparse array.
         this._childBoxes = Array(this._childSpecifications.length).fill(null);
+        
+        var instance = this;
+        this._ready = new Promise(function(resolve, reject) {
+            if (instance._specification.spawner === null) {
+                resolve(true);
+            }
+            else {
+                instance._specification.spawner.child_specifications(instance)
+                .then(specifications => {
+                    instance._childSpecifications = specifications;
+                    instance._childCount = instance._childSpecifications.length;
+                    instance._totalWeight = instance._childSpecifications.reduce(
+                        (accumulator, specification) => accumulator + specification.weight,
+                        0
+                    );
+
+                    instance._childBoxes = Array(instance._childSpecifications.length).fill(null);
+                    resolve(true);
+                })
+                .catch(error => reject(error));
+            }
+        });
     }
 
+    get ready() { return this._ready; }
     get colour() {return this._colour;}
     get text() {return this._text;}
     get prediction() {return this._prediction;}


### PR DESCRIPTION
Initial prototype for using UITextChecker as a predictions generator. 

Changes include:
- Use of promises for child specifications. Introduction of a ready property which can be tracked to render the box once the specifications are obtained.
- A completions predictor based on the original predictor which uses CaptiveWebView commands to access the native UITextChecker functionality.
- A new 'highlight' group used to visually track boxes with a weight assigned as a result of a prediction.

What needs to be reviewed:
- Asynchronous model for child specifications. Promises are used but I do wonder the impact in the rendering process.

Things that could be improved:
- Cache existing predictions as to prevent trips to the native side if a prediction for a prefix is already available.