### PR TITLE
A light-weight copy of the PPM language model code.

### DIFF
--- a/browser/dasher/third_party/jslm/LICENSE
+++ b/browser/dasher/third_party/jslm/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/browser/dasher/third_party/jslm/README.md
+++ b/browser/dasher/third_party/jslm/README.md
@@ -1,0 +1,76 @@
+# Adaptive Language Models in JavaScript
+
+This directory contains collection of simple adaptive language models that are
+cheap enough memory- and processor-wise to train in a browser on the fly.
+
+## Language Models
+
+### Prediction by Partial Matching (PPM)
+
+Prediction by Partial Matching (PPM) character [language model](ppm_language_model.js).
+
+#### Bibliography
+
+1.  Cleary, John G. and Witten, Ian H. (1984): [“Data Compression Using Adaptive Coding and Partial String Matching”](https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.14.4305), IEEE Transactions on Communications, vol. 32, no. 4, pp. 396&#x2013;402.
+2.  Moffat, Alistair (1990): [“Implementing the PPM data compression scheme”](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.120.8728&rep=rep1&type=pdf), IEEE Transactions on Communications, vol. 38, no. 11, pp. 1917&#x2013;1921.
+3.  Ney, Reinhard and Kneser, Hermann (1995): [“Improved backing-off for M-gram language modeling”](http://www-i6.informatik.rwth-aachen.de/publications/download/951/Kneser-ICASSP-1995.pdf), Proc. of Acoustics, Speech, and Signal Processing (ICASSP), May, pp. 181&#x2013;184. IEEE.
+4.  Chen, Stanley F. and Goodman, Joshua (1999): [“An empirical study of smoothing techniques for language modeling”](http://u.cs.biu.ac.il/~yogo/courses/mt2013/papers/chen-goodman-99.pdf), Computer Speech &#xff06; Language, vol. 13, no. 4, pp. 359&#x2013;394, Elsevier.
+5.  Ward, David J. and Blackwell, Alan F. and MacKay, David J. C. (2000): [“Dasher &#x2013; A Data Entry Interface Using Continuous Gestures and Language Models”](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.36.3318&rep=rep1&type=pdf), UIST '00 Proceedings of the 13th annual ACM symposium on User interface software and technology, pp. 129&#x2013;137, November, San Diego, USA.
+6.  Drinic, Milenko and Kirovski, Darko and Potkonjak, Miodrag (2003): [“PPM Model Cleaning”](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.5.4389&rep=rep1&type=pdf), Proc. of Data Compression Conference (DCC'2003), pp. 163&#x2013;172. March, Snowbird, UT, USA. IEEE
+7.  Jin Hu Huang and David Powers (2004): [“Adaptive Compression-based Approach for Chinese Pinyin Input”](https://www.aclweb.org/anthology/W04-1104.pdf), Proceedings of the Third SIGHAN Workshop on Chinese Language Processing, pp. 24&#x2013;27, Barcelona, Spain. ACL.
+8.  Cowans, Phil (2005): [“Language Modelling In Dasher &#x2013; A Tutorial”](http://www.inference.org.uk/pjc51/talks/05-dasher-lm.pdf), June, Inference Lab, Cambridge University (presentation).
+9.  Steinruecken, Christian and Ghahramani, Zoubin and MacKay, David (2016): [“Improving PPM with dynamic parameter updates”](https://www.repository.cam.ac.uk/bitstream/handle/1810/254106/Steinruecken%202015%20Data%20Compression%20Conference%202015.pdf), Proc. of Data Compression Conference (DCC'2015), pp. 193&#x2013;202, April, Snowbird, UT, USA. IEEE.
+10. Steinruecken, Christian (2015): [“Lossless Data Compression”](https://pdfs.semanticscholar.org/f506/884bb2aefd01ccf3d24a5964aad9ef698679.pdf), PhD dissertation, University of Cambridge.
+
+### Histogram Language Model
+
+Very simple context-less histogram character [language model](histogram_language_model.js).
+
+#### Bibliography
+
+1.  Steinruecken, Christian (2015): [“Lossless Data Compression”](https://pdfs.semanticscholar.org/f506/884bb2aefd01ccf3d24a5964aad9ef698679.pdf), PhD dissertation, University of Cambridge.
+2.  Pitman, Jim and Yor, Marc (1997): [“The two-parameter Poisson–Dirichlet distribution derived from a stable subordinator.”](https://projecteuclid.org/download/pdf_1/euclid.aop/1024404422), The Annals of Probability, vol. 25, no. 2, pp. 855&#x2013;900.
+3.  Stanley F. Chen and Joshua Goodman (1999): [“An empirical study of smoothing techniques for language modeling”](http://u.cs.biu.ac.il/~yogo/courses/mt2013/papers/chen-goodman-99.pdf), Computer Speech and Language, vol. 13, pp. 359&#x2013;394.
+
+### Pólya Tree (PT) Language Model
+
+Context-less predictive distribution based on balanced binary search trees. Tentative implementation is [here](polya_tree_language_model.js).
+
+#### Bibliography
+
+1.  Gleave, Adam and Steinruecken, Christian (2017): [“Making compression algorithms for Unicode text”](https://arxiv.org/pdf/1701.04047), arXiv preprint arXiv:1701.04047.
+2.  Steinruecken, Christian (2015): [“Lossless Data Compression”](https://pdfs.semanticscholar.org/f506/884bb2aefd01ccf3d24a5964aad9ef698679.pdf), PhD dissertation, University of Cambridge.
+3.  Mauldin, R. Daniel and Sudderth, William D. and Williams, S. C. (1992): [“Polya Trees and Random Distributions”](https://projecteuclid.org/download/pdf_1/euclid.aos/1176348766), The Annals of Statistics, vol. 20, no. 3, pp. 1203&#x2013;1221.
+4.  Lavine, Michael (1992): [“Some aspects of Polya tree distributions for statistical modelling”](https://projecteuclid.org/download/pdf_1/euclid.aos/1176348767), The Annals of Statistics, vol. 20, no. 3, pp. 1222&#x2013;1235.
+5.  Neath, Andrew A. (2003): [“Polya Tree Distributions for Statistical Modeling of Censored Data”](http://downloads.hindawi.com/journals/ads/2003/745230.pdf), Journal of Applied Mathematics and Decision Sciences, vol. 7, no. 3, pp. 175&#x2013;186.
+
+## Example
+
+Please see a simple example usage of the model API in [example.js](example.js).
+
+The example has no command-line arguments. To run it using
+[NodeJS](https://nodejs.org/en/) invoke
+
+```shell
+> node example.js
+```
+
+## Test Utility
+
+A simple test driver [language_model_driver.js](language_model_driver.js) can be
+used to check that the model behaves using [NodeJS](https://nodejs.org/en/). The
+driver takes three parameters: the maximum order for the language model, the
+training file and the test file in text format. Currently only the PPM model is
+supported.
+
+Example:
+
+```shell
+> node --max-old-space-size=4096 language_model_driver.js 7 training.txt test.txt
+Initializing vocabulary from training.txt ...
+Created vocabulary with 212 symbols.
+Constructing 7-gram LM ...
+Created trie with 21502513 nodes.
+Running over test.txt ...
+Results: numSymbols = 69302, ppl = 6.047012997396163, entropy = 2.5962226799087356 bits/char, OOVs = 0 (0%).
+```

--- a/browser/dasher/third_party/jslm/ppm_language_model.js
+++ b/browser/dasher/third_party/jslm/ppm_language_model.js
@@ -1,0 +1,499 @@
+// Copyright 2020 The Google Research Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Prediction by Partial Matching (PPM) language model.
+ *
+ * The original PPM algorithm is described in [1]. This particular
+ * implementation has been inspired by the PPM model used by Dasher, an
+ * Augmentative and alternative communication (AAC) input method developed by
+ * the Inference Group at University of Cambridge. The overview of the system
+ * is provided in [2]. The details of this algorithm, which is different from
+ * the standard PPM, are outlined in general terms in [3]. Please also see [4]
+ * for an excellent overview of various PPM variants.
+ *
+ * References:
+ * -----------
+ *   [1] Cleary, John G. and Witten, Ian H. (1984): “Data Compression Using
+ *       Adaptive Coding and Partial String Matching”, IEEE Transactions on
+ *       Communications, vol. 32, no. 4, pp. 396–402.
+ *   [2] Ward, David J. and Blackwell, Alan F. and MacKay, David J. C. (2000):
+ *       “Dasher - A Data Entry Interface Using Continuous Gestures and
+ *       Language Models”, UIST'00 Proceedings of the 13th annual ACM symposium
+ *       on User interface software and technology, pp. 129–137, November, San
+ *       Diego, USA.
+ *   [3] Cowans, Phil (2005): “Language Modelling In Dasher -- A Tutorial”,
+ *       June, Inference Lab, Cambridge University (presentation).
+ *   [4] Jin Hu Huang and David Powers (2004): "Adaptive Compression-based
+ *       Approach for Chinese Pinyin Input." Proceedings of the Third SIGHAN
+ *       Workshop on Chinese Language Processing, pp. 24--27, Barcelona, Spain,
+ *       ACL.
+ * Please also consult the references in README.md file in this directory.
+ */
+
+const assert = require("assert");
+
+const vocab = require("./vocabulary");
+
+/**
+ * Kneser-Ney "-like" smoothing parameters.
+ *
+ * These hardcoded values are copied from Dasher. Please see the documentation
+ * for PPMLanguageModel.getProbs() below for more information.
+ */
+const knAlpha = 0.49;
+const knBeta = 0.77;
+
+/* Epsilon for sanity checks. */
+const epsilon = 1E-10;
+
+/**
+ * Node in a search tree, which is implemented as a suffix trie that represents
+ * every suffix of a sequence used during its construction. Please see
+ *   [1] Moffat, Alistair (1990): "Implementing the PPM data compression
+ *       scheme", IEEE Transactions on Communications, vol. 38, no. 11, pp.
+ *       1917--1921.
+ *   [2] Esko Ukknonen (1995): "On-line construction of suffix trees",
+ *       Algorithmica, volume 14, pp. 249--260, Springer, 1995.
+ *   [3] Kennington, C. (2011): "Application of Suffix Trees as an
+ *       Implementation Technique for Varied-Length N-gram Language Models",
+ *       MSc. Thesis, Saarland University.
+ *
+ * @final
+ */
+class Node {
+  constructor() {
+    // Leftmost child node for the current node.
+    this.child_ = null;
+    // Next node.
+    this.next_ = null;
+    // Node in the backoff structure, also known as "vine" structure (see [1]
+    // above) and "suffix link" (see [2] above). The backoff for the given node
+    // points at the node representing the shorter context. For example, if the
+    // current node in the trie represents string "AA" (corresponding to the
+    // branch "[R] -> [A] -> [*A*]" in the trie, where [R] stands for root),
+    // then its backoff points at the node "A" (represented by "[R] ->
+    // [*A*]"). In this case both nodes are in the same branch but they don't
+    // need to be. For example, for the node "B" in the trie path for the string
+    // "AB" ("[R] -> [A] -> [*B*]") the backoff points at the child node of a
+    // different path "[R] -> [*B*]".
+    this.backoff_ = null;
+    // Frequency count for this node. Number of times the suffix symbol stored
+    // in this node was observed.
+    this.count_ = 1;
+    // Symbol that this node stores.
+    this.symbol_ = vocab.rootSymbol;
+  }
+
+  /**
+   * Finds child of the current node with a specified symbol.
+   * @param {number} symbol Integer symbol.
+   * @return {?Node} Node with the symbol.
+   * @final
+   */
+  findChildWithSymbol(symbol) {
+    let current = this.child_;
+    while (current != null) {
+      if (current.symbol_ == symbol) {
+        return current;
+      }
+      current = current.next_;
+    }
+    return current;
+  }
+
+  /**
+   * Total number of observations for all the children of this node. This
+   * counts all the events observed in this context.
+   *
+   * Note: This API is used at inference time. A possible alternative that will
+   * speed up the inference is to store the number of children in each node as
+   * originally proposed by Moffat for PPMB in
+   *   Moffat, Alistair (1990): "Implementing the PPM data compression scheme",
+   *   IEEE Transactions on Communications, vol. 38, no. 11, pp. 1917--1921.
+   * This however will increase the memory use of the algorithm which is already
+   * quite substantial.
+   *
+   * @param {!array} exclusionMask Boolean exclusion mask for all the symbols.
+   *                 Can be 'null', in which case no exclusion happens.
+   * @return {number} Total number of observations under this node.
+   * @final
+   */
+  totalChildrenCounts(exclusionMask) {
+    let childNode = this.child_;
+    let count = 0;
+    while (childNode != null) {
+      if (!exclusionMask || !exclusionMask[childNode.symbol_]) {
+        count += childNode.count_;
+      }
+      childNode = childNode.next_;
+    }
+    return count;
+  }
+}
+
+/**
+ * Handle encapsulating the search context.
+ * @final
+ */
+class Context {
+  /**
+   * Constructor.
+   * @param {?Node} head Head node of the context.
+   * @param {number} order Length of the context.
+   */
+  constructor(head, order) {
+    // Current node.
+    this.head_ = head;
+    // The order corresponding to length of the context.
+    this.order_ = order;
+  }
+}
+
+/**
+ * Prediction by Partial Matching (PPM) Language Model.
+ * @final
+ */
+class PPMLanguageModel {
+  /**
+   * @param {?Vocabulary} vocab Symbol vocabulary object.
+   * @param {number} maxOrder Maximum length of the context.
+   */
+  constructor(vocab, maxOrder) {
+    this.vocab_ = vocab;
+    assert(this.vocab_.size() > 1,
+           "Expecting at least two symbols in the vocabulary");
+
+    this.maxOrder_ = maxOrder;
+    this.root_ = new Node();
+    this.rootContext_ = new Context();
+    this.rootContext_.head_ = this.root_;
+    this.rootContext_.order_ = 0;
+    this.numNodes_ = 1;
+
+    // Exclusion mechanism: Off by default, but can be enabled during the
+    // run-time once the constructed suffix tree contains reliable counts.
+    this.useExclusion_ = false;
+  }
+
+  /**
+   * Adds symbol to the supplied node.
+   * @param {?Node} node Tree node which to grow.
+   * @param {number} symbol Symbol.
+   * @return {?Node} Node with the symbol.
+   * @final @private
+   */
+  addSymbolToNode_(node, symbol) {
+    let symbolNode = node.findChildWithSymbol(symbol);
+    if (symbolNode != null) {
+      // Update the counts for the given node and also for all the backoff nodes
+      // representing shorter contexts.
+      symbolNode.count_++;
+      let backoffNode = symbolNode.backoff_;
+      assert(backoffNode != null, "Expected valid backoff node!");
+      while (backoffNode != null) {
+        assert(backoffNode == this.root_ || backoffNode.symbol_ == symbol,
+               "Expected backoff node to be root or to contain " + symbol +
+               ". Found " + backoffNode.symbol_ + " instead");
+        backoffNode.count_++;
+        backoffNode = backoffNode.backoff_;
+      }
+    } else {
+      // Symbol does not exist under the given node. Create a new child node
+      // and update the backoff structure for lower contexts.
+      symbolNode = new Node();
+      symbolNode.symbol_ = symbol;
+      symbolNode.next_ = node.child_;
+      node.child_ = symbolNode;
+      this.numNodes_++;
+      if (node == this.root_) {
+        // Shortest possible context.
+        symbolNode.backoff_ = this.root_;
+      } else {
+        assert(node.backoff_ != null, "Expected valid backoff node");
+        symbolNode.backoff_ = this.addSymbolToNode_(node.backoff_, symbol);
+      }
+    }
+    return symbolNode;
+  }
+
+  /**
+   * Creates new context which is initially empty.
+   * @return {?Context} Context object.
+   * @final
+   */
+  createContext() {
+    return new Context(this.rootContext_.head_, this.rootContext_.order_);
+  }
+
+  /**
+   * Clones existing context.
+   * @param {?Context} context Existing context object.
+   * @return {?Context} Cloned context object.
+   * @final
+   */
+  cloneContext(context) {
+    return new Context(context.head_, context.order_);
+  }
+
+  /**
+   * Adds symbol to the supplied context. Does not update the model.
+   * @param {?Context} context Context object.
+   * @param {number} symbol Integer symbol.
+   * @final
+   */
+  addSymbolToContext(context, symbol) {
+    if (symbol <= vocab.rootSymbol) {  // Only add valid symbols.
+      return;
+    }
+    assert(symbol < this.vocab_.size(), "Invalid symbol: " + symbol);
+    while (context.head_ != null) {
+      if (context.order_ < this.maxOrder_) {
+        // Extend the current context.
+        const childNode = context.head_.findChildWithSymbol(symbol);
+        if (childNode != null) {
+          context.head_ = childNode;
+          context.order_++;
+          return;
+        }
+      }
+      // Try to extend the shorter context.
+      context.order_--;
+      context.head_ = context.head_.backoff_;
+    }
+    if (context.head_ == null) {
+      context.head_ = this.root_;
+      context.order_ = 0;
+    }
+  }
+
+  /**
+   * Adds symbol to the supplied context and updates the model.
+   * @param {?Context} context Context object.
+   * @param {number} symbol Integer symbol.
+   * @final
+   */
+  addSymbolAndUpdate(context, symbol) {
+    if (symbol <= vocab.rootSymbol) {  // Only add valid symbols.
+      return;
+    }
+    assert(symbol < this.vocab_.size(), "Invalid symbol: " + symbol);
+    const symbolNode = this.addSymbolToNode_(context.head_, symbol);
+    assert(symbolNode == context.head_.findChildWithSymbol(symbol));
+    context.head_ = symbolNode;
+    context.order_++;
+    while (context.order_ > this.maxOrder_) {
+      context.head_ = context.head_.backoff_;
+      context.order_--;
+    }
+  }
+
+  /**
+   * Returns probabilities for all the symbols in the vocabulary given the
+   * context.
+   *
+   * Notation:
+   * ---------
+   *         $x_h$ : Context representing history, $x_{h-1}$ shorter context.
+   *   $n(w, x_h)$ : Count of symbol $w$ in context $x_h$.
+   *      $T(x_h)$ : Total count in context $x_h$.
+   *      $q(x_h)$ : Number of symbols with non-zero counts seen in context
+   *                 $x_h$, i.e. |{w' : c(x_h, w') > 0}|. Alternatively, this
+   *                 represents the number of distinct extensions of history
+   *                 $x_h$ in the training data.
+   *
+   * Standard Kneser-Ney method (aka Absolute Discounting):
+   * ------------------------------------------------------
+   * Subtracting \beta (in [0, 1)) from all counts.
+   *   P_{kn}(w | x_h) = \frac{\max(n(w, x_h) - \beta, 0)}{T(x_h)} +
+   *                     \beta * \frac{q(x_h)}{T(x_h)} * P_{kn}(w | x_{h-1}),
+   * where the second term in summation represents escaping to lower-order
+   * context.
+   *
+   * See: Ney, Reinhard and Kneser, Hermann (1995): “Improved backing-off for
+   * M-gram language modeling”, Proc. of Acoustics, Speech, and Signal
+   * Processing (ICASSP), May, pp. 181–184.
+   *
+   * Modified Kneser-Ney method (Dasher version [3]):
+   * ------------------------------------------------
+   * Introducing \alpha parameter (in [0, 1)) and estimating as
+   *   P_{kn}(w | x_h) = \frac{\max(n(w, x_h) - \beta, 0)}{T(x_h) + \alpha} +
+   *                     \frac{\alpha + \beta * q(x_h)}{T(x_h) + \alpha} *
+   *                     P_{kn}(w | x_{h-1}) .
+   *
+   * Additional details on the above version are provided in Sections 3 and 4
+   * of:
+   *   Steinruecken, Christian and Ghahramani, Zoubin and MacKay, David (2016):
+   *   "Improving PPM with dynamic parameter updates", In Proc. Data
+   *   Compression Conference (DCC-2015), pp. 193--202, April, Snowbird, UT,
+   *   USA. IEEE.
+   *
+   * @param {?Context} context Context symbols.
+   * @return {?array} Array of floating point probabilities corresponding to all
+   *                  the symbols in the vocabulary plus the 0th element
+   *                  representing the root of the tree that should be ignored.
+   * @final
+   */
+  getProbs(context) {
+    // Initialize the initial estimates. Note, we don't use uniform
+    // distribution here.
+    const numSymbols = this.vocab_.size();
+    let probs = new Array(numSymbols);
+    for (let i = 0; i < numSymbols; ++i) {
+      probs[i] = 0.0;
+    }
+
+    // Initialize the exclusion mask.
+    let exclusionMask = null;
+    if (this.useExclusion_) {
+      exclusionMask = new Array(numSymbols);
+      for (let i = 0; i < numSymbols; ++i) {
+        exclusionMask[i] = false;
+      }
+    }
+
+    // Estimate the probabilities for all the symbols in the supplied context.
+    // This runs over all the symbols in the context and over all the suffixes
+    // (orders) of the context. If the exclusion mechanism is enabled, the
+    // estimate for a higher-order ngram is fully trusted and is excluded from
+    // further interpolation with lower-order estimates.
+    //
+    // Exclusion mechanism is disabled by default. Enable it with care: it has
+    // been shown to work well on large corpora, but may in theory degrade the
+    // performance on smaller sets (as we observed with default Dasher English
+    // training data).
+    let totalMass = 1.0;
+    let node = context.head_;
+    let gamma = totalMass;
+    while (node != null) {
+      const count = node.totalChildrenCounts(exclusionMask);
+      if (count > 0) {
+        let childNode = node.child_;
+        while (childNode != null) {
+          const symbol = childNode.symbol_;
+          if (!exclusionMask || !exclusionMask[symbol]) {
+            const p = gamma * (childNode.count_ - knBeta) / (count + knAlpha);
+            probs[symbol] += p;
+            totalMass -= p;
+            if (exclusionMask) {
+              exclusionMask[symbol] = true;
+            }
+          }
+          childNode = childNode.next_;
+        }
+      }
+
+      // Backoff to lower-order context. The $\gamma$ factor represents the
+      // total probability mass after processing the current $n$-th order before
+      // backing off to $n-1$-th order. It roughly corresponds to the usual
+      // interpolation parameter, as used in the literature, e.g. in
+      //   Stanley F. Chen and Joshua Goodman (1999): "An empirical study of
+      //   smoothing techniques for language modeling", Computer Speech and
+      //   Language, vol. 13, pp. 359-–394.
+      //
+      // Note on computing $gamma$:
+      // --------------------------
+      // According to the PPM papers, and in particular the Section 4 of
+      //   Steinruecken, Christian and Ghahramani, Zoubin and MacKay,
+      //   David (2016): "Improving PPM with dynamic parameter updates", In
+      //   Proc. Data Compression Conference (DCC-2015), pp. 193--202, April,
+      //   Snowbird, UT, USA. IEEE,
+      // that describes blending (i.e. interpolation), the second multiplying
+      // factor in the interpolation $\lambda$ for a given suffix node $x_h$ in
+      // the tree is given by
+      //   \lambda(x_h) = \frac{q(x_h) * \beta + \alpha}{T(x_h) + \alpha} .
+      // It can be shown that
+      //   \gamma(x_h) = 1.0 - \sum_{w'}
+      //      \frac{\max(n(w', x_h) - \beta, 0)}{T(x_h) + \alpha} =
+      //      \lambda(x_h)
+      // and, in the update below, the following is equivalent:
+      //   \gamma = \gamma * \gamma(x_h) = totalMass .
+      //
+      // Since gamma *= (numChildren * knBeta + knAlpha) / (count + knAlpha) is
+      // expensive, we assign the equivalent totalMass value to gamma.
+      node = node.backoff_;
+      gamma = totalMass;
+    }
+    assert(totalMass >= 0.0,
+           "Invalid remaining probability mass: " + totalMass);
+
+    // Count the total number of symbols that should have their estimates
+    // blended with the uniform distribution representing the zero context.
+    // When exclusion mechanism is enabled (by enabling this.useExclusion_)
+    // this number will represent the number of symbols not seen during the
+    // training, otherwise, this number will be equal to total number of
+    // symbols because we always interpolate with the estimates for an empty
+    // context.
+    let numUnseenSymbols = 0;
+    for (let i = 1; i < numSymbols; ++i) {
+      if (!exclusionMask || !exclusionMask[i]) {
+        numUnseenSymbols++;
+      }
+    }
+
+    // Adjust the probability mass for all the symbols.
+    const remainingMass = totalMass;
+    for (let i = 1; i < numSymbols; ++i) {
+      // Following is estimated according to a uniform distribution
+      // corresponding to the context length of zero.
+      if (!exclusionMask || !exclusionMask[i]) {
+        const p = remainingMass / numUnseenSymbols;
+        probs[i] += p;
+        totalMass -= p;
+      }
+    }
+    let leftSymbols = numSymbols - 1;
+    let newProbMass = 0.0;
+    for (let i = 1; i < numSymbols; ++i) {
+      const p = totalMass / leftSymbols;
+      probs[i] += p;
+      totalMass -= p;
+      newProbMass += probs[i];
+      --leftSymbols;
+    }
+    assert(totalMass == 0.0, "Expected remaining probability mass to be zero!");
+    assert(Math.abs(1.0 - newProbMass) < epsilon);
+    return probs;
+  }
+
+  /**
+   * Prints the trie to console.
+   * @param {?Node} node Current trie node.
+   * @param {string} indent Indentation prefix.
+   * @final @private
+   */
+  printToConsole_(node, indent) {
+    console.log(indent + "  " + this.vocab_.symbols_[node.symbol_] +
+                "(" + node.symbol_ + ") [" + node.count_ + "]");
+    indent += "  ";
+    let child = node.child_;
+    while (child != null) {
+      this.printToConsole_(child, indent);
+      child = child.next_;
+    }
+  }
+
+  /**
+   * Prints the trie to console.
+   * @final
+   */
+  printToConsole() {
+    this.printToConsole_(this.root_, "");
+  }
+}
+
+/**
+ * Exported APIs.
+ */
+exports.PPMLanguageModel = PPMLanguageModel;

--- a/browser/dasher/third_party/jslm/vocabulary.js
+++ b/browser/dasher/third_party/jslm/vocabulary.js
@@ -1,0 +1,92 @@
+// Copyright 2020 The Google Research Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Simple vocabulary abstraction.
+ *
+ * This is used to store symbols and map them to contiguous integers.
+ */
+
+// Special symbol denoting the root node.
+const rootSymbol = 0;
+
+// Symbol name of the root symbol, also used for out-of-vocabulary symbols.
+const rootSymbolName = "<R>";
+
+// The special out-of-vocabulary (OOV) symbol.
+const oovSymbol = "<OOV>";
+
+/**
+ * Vocabulary of symbols, which is a set of symbols that map one-to-one to
+ * unique integers.
+ * @final
+ */
+class Vocabulary {
+  constructor() {
+    this.symbols_ = Array();
+    this.symbols_.push(rootSymbolName);
+    this.oovSymbol_ = -1;
+  }
+
+  /**
+   * Adds symbol to the vocabulary returning its unique ID.
+   * @param {string} symbol Symbol to be added.
+   * @return {number} Symbol ID.
+   * @final
+   */
+  addSymbol(symbol) {
+    let pos = this.symbols_.indexOf(symbol);
+    if (pos >= 0) {
+      return pos;
+    }
+    // The current symbol container length is used as a unique ID. Because
+    // the symbol IDs are used to index the array directly, the symbol ID is
+    // assigned before updating the array.
+    const symbol_id = this.symbols_.length;
+    this.symbols_.push(symbol);
+    return symbol_id;
+  }
+
+  /**
+   * Returns the vocabulary symbol ID if it exists, otherwise maps the supplied
+   * symbol to out-of-vocabulary (OOV) symbol. Note, this method is *only* used
+   * for testing.
+   * @param {string} symbol Symbol to be looked up.
+   * @return {number} Symbol ID.
+   * @final
+   */
+  getSymbolOrOOV(symbol) {
+    let pos = this.symbols_.indexOf(symbol);
+    if (pos >= 0) {
+      return pos;
+    }
+    this.oovSymbol_ = this.addSymbol(oovSymbol);
+    return this.oovSymbol_;
+  }
+
+  /**
+   * Returns cardinality of the vocabulary.
+   * @return {number} Size.
+   * @final
+   */
+  size() {
+    return this.symbols_.length;
+  }
+}
+
+/**
+ * Exported APIs.
+ */
+exports.rootSymbol = rootSymbol;
+exports.Vocabulary = Vocabulary;

--- a/browser/dasher/third_party/readme.md
+++ b/browser/dasher/third_party/readme.md
@@ -5,5 +5,5 @@
 A copy of a small
 [library](https://github.com/google-research/google-research/tree/master/jslm)
 of dynamic language models in JavaScript by Google.  The copy contains a subset
-of the classes required to implement the Precition by Partial Matching (PPM)
+of the classes required to implement the Prediction by Partial Matching (PPM)
 language model.

--- a/browser/dasher/third_party/readme.md
+++ b/browser/dasher/third_party/readme.md
@@ -1,0 +1,9 @@
+# Third-party components
+
+## jslm
+
+A copy of a small
+[library](https://github.com/google-research/google-research/tree/master/jslm)
+of dynamic language models in JavaScript by Google.  The copy contains a subset
+of the classes required to implement the Precition by Partial Matching (PPM)
+language model.


### PR DESCRIPTION
Creating a `third_party/jslm` directory with a copy of the PPM language model cloned from the Google Research [repository](https://github.com/google-research/google-research/tree/master/jslm). We will maintain the implementation in sync with the original.

Please see the original `third_party/jslm/README.md` for more information.